### PR TITLE
[1.20.x Fabric] Tags and Fixes

### DIFF
--- a/src/main/generated/data/rootsclassic/loot_tables/blocks/accelerator_standing_stone.json
+++ b/src/main/generated/data/rootsclassic/loot_tables/blocks/accelerator_standing_stone.json
@@ -1,0 +1,30 @@
+{
+  "type": "minecraft:block",
+  "pools": [
+    {
+      "bonus_rolls": 0.0,
+      "conditions": [
+        {
+          "condition": "minecraft:survives_explosion"
+        }
+      ],
+      "entries": [
+        {
+          "type": "minecraft:item",
+          "conditions": [
+            {
+              "block": "rootsclassic:accelerator_standing_stone",
+              "condition": "minecraft:block_state_property",
+              "properties": {
+                "half": "lower"
+              }
+            }
+          ],
+          "name": "rootsclassic:accelerator_standing_stone"
+        }
+      ],
+      "rolls": 1.0
+    }
+  ],
+  "random_sequence": "rootsclassic:blocks/accelerator_standing_stone"
+}

--- a/src/main/generated/data/rootsclassic/loot_tables/blocks/aesthetic_standing_stone.json
+++ b/src/main/generated/data/rootsclassic/loot_tables/blocks/aesthetic_standing_stone.json
@@ -1,0 +1,30 @@
+{
+  "type": "minecraft:block",
+  "pools": [
+    {
+      "bonus_rolls": 0.0,
+      "conditions": [
+        {
+          "condition": "minecraft:survives_explosion"
+        }
+      ],
+      "entries": [
+        {
+          "type": "minecraft:item",
+          "conditions": [
+            {
+              "block": "rootsclassic:aesthetic_standing_stone",
+              "condition": "minecraft:block_state_property",
+              "properties": {
+                "half": "lower"
+              }
+            }
+          ],
+          "name": "rootsclassic:aesthetic_standing_stone"
+        }
+      ],
+      "rolls": 1.0
+    }
+  ],
+  "random_sequence": "rootsclassic:blocks/aesthetic_standing_stone"
+}

--- a/src/main/generated/data/rootsclassic/loot_tables/blocks/attuned_standing_stone.json
+++ b/src/main/generated/data/rootsclassic/loot_tables/blocks/attuned_standing_stone.json
@@ -1,0 +1,30 @@
+{
+  "type": "minecraft:block",
+  "pools": [
+    {
+      "bonus_rolls": 0.0,
+      "conditions": [
+        {
+          "condition": "minecraft:survives_explosion"
+        }
+      ],
+      "entries": [
+        {
+          "type": "minecraft:item",
+          "conditions": [
+            {
+              "block": "rootsclassic:attuned_standing_stone",
+              "condition": "minecraft:block_state_property",
+              "properties": {
+                "half": "lower"
+              }
+            }
+          ],
+          "name": "rootsclassic:attuned_standing_stone"
+        }
+      ],
+      "rolls": 1.0
+    }
+  ],
+  "random_sequence": "rootsclassic:blocks/attuned_standing_stone"
+}

--- a/src/main/generated/data/rootsclassic/loot_tables/blocks/entangler_standing_stone.json
+++ b/src/main/generated/data/rootsclassic/loot_tables/blocks/entangler_standing_stone.json
@@ -1,0 +1,30 @@
+{
+  "type": "minecraft:block",
+  "pools": [
+    {
+      "bonus_rolls": 0.0,
+      "conditions": [
+        {
+          "condition": "minecraft:survives_explosion"
+        }
+      ],
+      "entries": [
+        {
+          "type": "minecraft:item",
+          "conditions": [
+            {
+              "block": "rootsclassic:entangler_standing_stone",
+              "condition": "minecraft:block_state_property",
+              "properties": {
+                "half": "lower"
+              }
+            }
+          ],
+          "name": "rootsclassic:entangler_standing_stone"
+        }
+      ],
+      "rolls": 1.0
+    }
+  ],
+  "random_sequence": "rootsclassic:blocks/entangler_standing_stone"
+}

--- a/src/main/generated/data/rootsclassic/loot_tables/blocks/grower_standing_stone.json
+++ b/src/main/generated/data/rootsclassic/loot_tables/blocks/grower_standing_stone.json
@@ -1,0 +1,30 @@
+{
+  "type": "minecraft:block",
+  "pools": [
+    {
+      "bonus_rolls": 0.0,
+      "conditions": [
+        {
+          "condition": "minecraft:survives_explosion"
+        }
+      ],
+      "entries": [
+        {
+          "type": "minecraft:item",
+          "conditions": [
+            {
+              "block": "rootsclassic:grower_standing_stone",
+              "condition": "minecraft:block_state_property",
+              "properties": {
+                "half": "lower"
+              }
+            }
+          ],
+          "name": "rootsclassic:grower_standing_stone"
+        }
+      ],
+      "rolls": 1.0
+    }
+  ],
+  "random_sequence": "rootsclassic:blocks/grower_standing_stone"
+}

--- a/src/main/generated/data/rootsclassic/loot_tables/blocks/healer_standing_stone.json
+++ b/src/main/generated/data/rootsclassic/loot_tables/blocks/healer_standing_stone.json
@@ -1,0 +1,30 @@
+{
+  "type": "minecraft:block",
+  "pools": [
+    {
+      "bonus_rolls": 0.0,
+      "conditions": [
+        {
+          "condition": "minecraft:survives_explosion"
+        }
+      ],
+      "entries": [
+        {
+          "type": "minecraft:item",
+          "conditions": [
+            {
+              "block": "rootsclassic:healer_standing_stone",
+              "condition": "minecraft:block_state_property",
+              "properties": {
+                "half": "lower"
+              }
+            }
+          ],
+          "name": "rootsclassic:healer_standing_stone"
+        }
+      ],
+      "rolls": 1.0
+    }
+  ],
+  "random_sequence": "rootsclassic:blocks/healer_standing_stone"
+}

--- a/src/main/generated/data/rootsclassic/loot_tables/blocks/igniter_standing_stone.json
+++ b/src/main/generated/data/rootsclassic/loot_tables/blocks/igniter_standing_stone.json
@@ -1,0 +1,30 @@
+{
+  "type": "minecraft:block",
+  "pools": [
+    {
+      "bonus_rolls": 0.0,
+      "conditions": [
+        {
+          "condition": "minecraft:survives_explosion"
+        }
+      ],
+      "entries": [
+        {
+          "type": "minecraft:item",
+          "conditions": [
+            {
+              "block": "rootsclassic:igniter_standing_stone",
+              "condition": "minecraft:block_state_property",
+              "properties": {
+                "half": "lower"
+              }
+            }
+          ],
+          "name": "rootsclassic:igniter_standing_stone"
+        }
+      ],
+      "rolls": 1.0
+    }
+  ],
+  "random_sequence": "rootsclassic:blocks/igniter_standing_stone"
+}

--- a/src/main/generated/data/rootsclassic/loot_tables/blocks/repulsor_standing_stone.json
+++ b/src/main/generated/data/rootsclassic/loot_tables/blocks/repulsor_standing_stone.json
@@ -1,0 +1,30 @@
+{
+  "type": "minecraft:block",
+  "pools": [
+    {
+      "bonus_rolls": 0.0,
+      "conditions": [
+        {
+          "condition": "minecraft:survives_explosion"
+        }
+      ],
+      "entries": [
+        {
+          "type": "minecraft:item",
+          "conditions": [
+            {
+              "block": "rootsclassic:repulsor_standing_stone",
+              "condition": "minecraft:block_state_property",
+              "properties": {
+                "half": "lower"
+              }
+            }
+          ],
+          "name": "rootsclassic:repulsor_standing_stone"
+        }
+      ],
+      "rolls": 1.0
+    }
+  ],
+  "random_sequence": "rootsclassic:blocks/repulsor_standing_stone"
+}

--- a/src/main/generated/data/rootsclassic/loot_tables/blocks/vacuum_standing_stone.json
+++ b/src/main/generated/data/rootsclassic/loot_tables/blocks/vacuum_standing_stone.json
@@ -1,0 +1,30 @@
+{
+  "type": "minecraft:block",
+  "pools": [
+    {
+      "bonus_rolls": 0.0,
+      "conditions": [
+        {
+          "condition": "minecraft:survives_explosion"
+        }
+      ],
+      "entries": [
+        {
+          "type": "minecraft:item",
+          "conditions": [
+            {
+              "block": "rootsclassic:vacuum_standing_stone",
+              "condition": "minecraft:block_state_property",
+              "properties": {
+                "half": "lower"
+              }
+            }
+          ],
+          "name": "rootsclassic:vacuum_standing_stone"
+        }
+      ],
+      "rolls": 1.0
+    }
+  ],
+  "random_sequence": "rootsclassic:blocks/vacuum_standing_stone"
+}

--- a/src/main/resources/assets/rootsclassic/lang/en_us.json
+++ b/src/main/resources/assets/rootsclassic/lang/en_us.json
@@ -507,7 +507,7 @@
     "rootsclassic.mortar.disabled": "Recipe disabled",
     "rootsclassic.mortar.mixin": "Recipe found but missing a Rare Material mixin",
 
-    "entity.rootsclassic.skeleton_phantom": "Phantom Skeleton",
+    "entity.rootsclassic.phantom_skeleton": "Phantom Skeleton",
     "entity.rootsclassic.tile_accelerator": "Tile Accelerator",
     "entity.rootsclassic.entity_accelerator": "Entity Accelerator",
 

--- a/src/main/resources/data/minecraft/tags/blocks/mineable/axe.json
+++ b/src/main/resources/data/minecraft/tags/blocks/mineable/axe.json
@@ -1,0 +1,6 @@
+{
+    "replace": false,
+    "values": [
+      "rootsclassic:imbuer"
+    ]
+}

--- a/src/main/resources/data/minecraft/tags/blocks/mineable/pickaxe.json
+++ b/src/main/resources/data/minecraft/tags/blocks/mineable/pickaxe.json
@@ -1,0 +1,18 @@
+{
+    "replace": false,
+    "values": [
+      "rootsclassic:mundane_standing_stone",
+      "rootsclassic:attuned_standing_stone",
+      "rootsclassic:vacuum_standing_stone",
+      "rootsclassic:repulsor_standing_stone",
+      "rootsclassic:accelerator_standing_stone",
+      "rootsclassic:aesthetic_standing_stone",
+      "rootsclassic:entangler_standing_stone",
+      "rootsclassic:igniter_standing_stone",
+      "rootsclassic:grower_standing_stone",
+      "rootsclassic:healer_standing_stone",
+      "rootsclassic:altar",
+      "rootsclassic:brazier",
+      "rootsclassic:imbuer"
+    ]
+}

--- a/src/main/resources/data/minecraft/tags/blocks/small_flowers.json
+++ b/src/main/resources/data/minecraft/tags/blocks/small_flowers.json
@@ -1,0 +1,8 @@
+{
+    "replace": false,
+    "values": [
+      "rootsclassic:midnight_bloom",
+      "rootsclassic:flare_orchid",
+      "rootsclassic:radiant_daisy"
+    ]
+}

--- a/src/main/resources/data/minecraft/tags/items/axes.json
+++ b/src/main/resources/data/minecraft/tags/items/axes.json
@@ -1,0 +1,6 @@
+{
+    "replace": false,
+    "values": [
+      "rootsclassic:living_axe"
+    ]
+}

--- a/src/main/resources/data/minecraft/tags/items/hoes.json
+++ b/src/main/resources/data/minecraft/tags/items/hoes.json
@@ -1,0 +1,6 @@
+{
+    "replace": false,
+    "values": [
+      "rootsclassic:living_hoe"
+    ]
+}

--- a/src/main/resources/data/minecraft/tags/items/pickaxes.json
+++ b/src/main/resources/data/minecraft/tags/items/pickaxes.json
@@ -1,0 +1,6 @@
+{
+    "replace": false,
+    "values": [
+      "rootsclassic:living_pickaxe"
+    ]
+}

--- a/src/main/resources/data/minecraft/tags/items/shovels.json
+++ b/src/main/resources/data/minecraft/tags/items/shovels.json
@@ -1,0 +1,6 @@
+{
+    "replace": false,
+    "values": [
+      "rootsclassic:living_shovel"
+    ]
+}

--- a/src/main/resources/data/minecraft/tags/items/small_flowers.json
+++ b/src/main/resources/data/minecraft/tags/items/small_flowers.json
@@ -1,0 +1,8 @@
+{
+    "replace": false,
+    "values": [
+      "rootsclassic:midnight_bloom",
+      "rootsclassic:flare_orchid",
+      "rootsclassic:radiant_daisy"
+    ]
+}

--- a/src/main/resources/data/minecraft/tags/items/swords.json
+++ b/src/main/resources/data/minecraft/tags/items/swords.json
@@ -1,0 +1,7 @@
+{
+    "replace": false,
+    "values": [
+      "rootsclassic:living_sword",
+      "rootsclassic:engraved_blade"
+    ]
+}


### PR DESCRIPTION
## Tags
[Added roots' items and block to common minecraft's item/block tags](https://github.com/ZestyBlaze/RootsClassic/pull/4/commits/8d7d3976f2c00fbcc2a40482f9b42736b640c3ed)

- Added `Standing Stones` to `minecraft:minable/pickaxe` block tag, thus making the Standing Stones be mined faster with pickaxes.

- Added `Casting Altar` to `minecraft:minable/pickaxe` block tag, thus making the Casting Altar be mined faster with pickaxes.

- Added `Incense Brazier` to `minecraft:minable/pickaxe` block tag, thus making the Incense Brazier be mined faster with pickaxes.

- Added `Imbuer` to `minecraft:minable/pickaxe` and `minecraft:mineable\pickaxe` block tag, thus making the Imbuer be mined faster with axes and pickaxes.

- Added `Midnight Bloom`, `Flare Orchid` and `Radiant Daisy` to `minecraft:small_flowers` block and item tags.

- Added all `Living Tools` and `Engraved Blade` to their corresponding tools item tag like like `minecraft:swords`, `minecraft:axes`, `minecraft:hoes`, etc...

## Lang File

- [Fixed **`phantom_skeleton`'s** lang entry.](https://github.com/ZestyBlaze/RootsClassic/pull/4/commits/c41a46a2083dc71196e6d2f8a8f95fb6a81384d5)

## Loot Tables

- [Fixed missing **`loot_tables`** for **`Standing Stones`**.](https://github.com/ZestyBlaze/RootsClassic/pull/4/commits/06134dc57342e04e5e0e2533f9b360d2b60a2f31)