### PR TITLE
Add all blocks to the `#minecraft:mineable/pickaxe tag`

### DIFF
--- a/src/main/resources/data/minecraft/tags/blocks/mineable/pickaxe.json
+++ b/src/main/resources/data/minecraft/tags/blocks/mineable/pickaxe.json
@@ -1,0 +1,18 @@
+{
+	"values": [
+		"rootsclassic:mortar",
+		"rootsclassic:imbuer",
+		"rootsclassic:altar",
+		"rootsclassic:brazier",
+		"rootsclassic:mundane_standing_stone",
+		"rootsclassic:attuned_standing_stone",
+		"rootsclassic:aesthetic_standing_stone",
+		"rootsclassic:vacuum_standing_stone",
+		"rootsclassic:repulsor_standing_stone",
+		"rootsclassic:accelerator_standing_stone",
+		"rootsclassic:entangler_standing_stone",
+		"rootsclassic:igniter_standing_stone",
+		"rootsclassic:grower_standing_stone",
+		"rootsclassic:healer_standing_stone"
+	]
+}


### PR DESCRIPTION
This allows the blocks to be mined faster with a pickaxe.  
They will still drop as items when mined with no or any other tool.